### PR TITLE
Added NoWarn for CS8983 (A 'struct' with field initializers must incl…

### DIFF
--- a/src/IISLogManager.Core/IISLogManager.Core.csproj
+++ b/src/IISLogManager.Core/IISLogManager.Core.csproj
@@ -5,6 +5,7 @@
 		<DefaultNamespace>IISLogManager.Core</DefaultNamespace>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
+		<NoWarn>8983</NoWarn>
 	</PropertyGroup>
 	<ItemGroup>
 		<Compile Remove="scratch\**" />


### PR DESCRIPTION
Added NoWarn for CS8983 (A 'struct' with field initializers must include an explicitly declared constructor.)

﻿<font color="dark red"><b> NOTE:</b></font> This process is still evolving. Please check back regularly for updates